### PR TITLE
Button groups

### DIFF
--- a/src/scss/views/buttons/_button.scss
+++ b/src/scss/views/buttons/_button.scss
@@ -194,3 +194,22 @@
     }
   }
 }
+
+.button-group {
+  display: flex;
+
+  .button-component:first-of-type {
+    border-radius: $border-radius-small 0 0 $border-radius-small;
+    border-width: 1px 1px 1px 1px;
+  }
+
+  .button-component:last-of-type {
+    border-width: 1px 1px 1px 0px;
+    border-radius: 0 $border-radius-small $border-radius-small 0;
+  }
+
+  .button-component:not(:first-child):not(:last-child) {
+    border-radius: 0;
+    border-left: none;
+  }
+}

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -27,3 +27,4 @@ export { default as Slider } from './views/widgets/slider';
 export { default as BreadCrumbs } from './views/widgets/breadcrumbs';
 export { default as Image } from './views/widgets/image';
 export { default as CircleButton } from './views/buttons/circle';
+export { default as ButtonGroup } from './views/buttons/button-group';

--- a/src/ts/views/buttons/button-group.tsx
+++ b/src/ts/views/buttons/button-group.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+const ButtonGroup = ({ children }: {
+  children: any
+}) => {
+  return (
+    <div className="button-group">
+      {children}
+    </div>
+  );
+};
+
+export default ButtonGroup;

--- a/viewer-app/root.tsx
+++ b/viewer-app/root.tsx
@@ -19,7 +19,8 @@ import {
   Slider,
   BreadCrumbs,
   Image,
-  CircleButton
+  CircleButton,
+  ButtonGroup
 } from '../src/ts/index';
 
 class Root extends React.Component<{}, {
@@ -137,6 +138,15 @@ class Root extends React.Component<{}, {
 
     return (
       <div style={wrapperStyle}>
+
+        <ComponentSection title={'Button Group'}>
+          <ButtonGroup>
+            <Button color="white" disabled={false}>{'Click'}</Button>
+            <Button color="white" disabled={false}>{'Click2'}</Button>
+            <Button color="white" disabled={false}>{'Click3'}</Button>
+            <Button color="white" disabled={false}>{'Click4'}</Button>
+          </ButtonGroup>
+        </ComponentSection>
 
         <ComponentSection title={'Pagination'}>
           <Pagination activePage={8} totalPages={12} onClick={() => {}}/>


### PR DESCRIPTION
![screen shot 2018-05-10 at 9 59 02 am](https://user-images.githubusercontent.com/5408720/39873602-61273a66-5439-11e8-8ae3-ae496c21eba0.png)

Applies proper border-radius and removes extra borders and puts buttons together!

Usage is as such:

```jsx
<ButtonGroup>
  <Button color="white" disabled={false}>{'Click'}</Button>
  <Button color="white" disabled={false}>{'Click2'}</Button>
  <Button color="white" disabled={false}>{'Click3'}</Button>
  <Button color="white" disabled={false}>{'Click4'}</Button>
</ButtonGroup>
```