### PR TITLE
Toasts: notifications init

### DIFF
--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -26,3 +26,4 @@
 @import "views/widgets/_image.scss";
 @import "views/widgets/_pagination.scss";
 @import "views/widgets/_avatar.scss";
+@import "views/widgets/_toast.scss";

--- a/src/scss/views/widgets/_toast.scss
+++ b/src/scss/views/widgets/_toast.scss
@@ -1,0 +1,51 @@
+.toast-wrapper {
+  position: fixed;
+  bottom: 0;
+  right: $base-spacing-double;
+  z-index: 2;
+}
+
+.toast {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: $base-spacing-quad $base-spacing-quad;
+  background-color: $color-black;
+  color: $color-white;
+  font-weight: $font-weight-semibold;
+  border-radius: $border-radius-small;
+  max-height: 100%;
+  transition: max-height 0.3s ease-out, opacity 0.3s ease-out;
+  opacity: 1;
+  margin-bottom: $base-spacing-double;
+
+  &.isClosing {
+    max-height: 0;
+    opacity: 0;
+  }
+
+  .toast-content {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .toast-dismiss {
+    width: 14px;
+    cursor: pointer;
+    color: $color-black;
+    padding: $base-spacing;
+    margin-left: $base-spacing-sex;
+    font-weight: $font-weight-semibold;
+  }
+
+  &:hover {
+    .toast-dismiss {
+      display: inline-block;
+      display: inline-block;
+      background: $color-white;
+      color: $color-black;
+      border-radius: $border-radius-circle;
+    }
+  }
+}

--- a/src/scss/views/widgets/_toast.scss
+++ b/src/scss/views/widgets/_toast.scss
@@ -35,7 +35,7 @@
     cursor: pointer;
     color: $color-black;
     padding: $base-spacing;
-    margin-left: $base-spacing-sex;
+    margin-left: $base-spacing-quad;
     font-weight: $font-weight-semibold;
   }
 

--- a/src/scss/views/widgets/_toast.scss
+++ b/src/scss/views/widgets/_toast.scss
@@ -42,7 +42,6 @@
   &:hover {
     .toast-dismiss {
       display: inline-block;
-      display: inline-block;
       background: $color-white;
       color: $color-black;
       border-radius: $border-radius-circle;

--- a/src/tests/views/widgets/pagination.test.tsx
+++ b/src/tests/views/widgets/pagination.test.tsx
@@ -71,7 +71,6 @@ test('<Pagination/> renders corrent # of buttons when active page is not last pa
     />
   );
   const buttonAmount = wrapper.find('PageButton').length;
-  console.log(buttonAmount);
   t.is(buttonAmount, 6);
 });
 

--- a/src/tests/views/widgets/toast.test.tsx
+++ b/src/tests/views/widgets/toast.test.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import * as sinon from 'sinon';
+import test from 'ava';
+import { shallow } from 'enzyme';
+import Toast from '../../../ts/views/widgets/toast';
+
+const wait = (delay = 1000) => new Promise((resolve) => setTimeout(resolve, delay));
+
+test('Toast works and closes after animation', async (t) => {
+  const onClose = sinon.spy();
+
+  const wrapper = shallow(
+    <Toast onClose={onClose}>
+      {'hi'}
+    </Toast>
+  );
+
+  wrapper.find('.toast-dismiss').first().simulate('click');
+
+  // Toast has received transition css classname, animates for 500ms then
+  // calls the onClose prop.
+  t.is(wrapper.hasClass('isClosing'), true);
+
+  await wait();
+  t.is(onClose.calledOnce, true);
+});
+
+test('Toast with timeout works', async (t) => {
+  const onClose = sinon.spy();
+
+  const wrapper = shallow(
+    <Toast onClose={onClose} timeout={500}>
+      {'hi'}
+    </Toast>
+  );
+
+  await wait(2000);
+
+  // Should only be called once and automatically
+  t.is(onClose.calledOnce, true);
+});
+
+test('Toast works and cancels timeout when clicked', async (t) => {
+  const onClose = sinon.spy();
+
+  const wrapper = shallow(
+    <Toast onClose={onClose} timeout={5000}>
+      {'hi'}
+    </Toast>
+  );
+
+  wrapper.find('.toast-dismiss').first().simulate('click');
+  await wait(2500);
+
+  // Should only be called once
+  t.is(onClose.calledOnce, true);
+});

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -29,3 +29,4 @@ export { default as ButtonGroup } from './views/buttons/button-group';
 export { default as Avatar } from './views/widgets/avatar';
 export { default as NumberInput } from './views/inputs/number-input';
 export { default as UserPill } from './views/widgets/user-pill';
+export { default as Toast } from './views/widgets/toast';

--- a/src/ts/views/widgets/toast.tsx
+++ b/src/ts/views/widgets/toast.tsx
@@ -6,12 +6,14 @@ class Toast extends React.Component<{
   timeout?: number,
   onClose?: () => void
 }, {
-  isClosing?: boolean
+  isClosing?: boolean,
+  timeoutInterval?: any
 }> {
   constructor(props: any) {
     super(props);
     this.state = {
-      isClosing: false
+      isClosing: false,
+      timeoutInterval: null
     };
   }
 
@@ -20,12 +22,22 @@ class Toast extends React.Component<{
     const { timeout } = this.props;
 
     if (timeout) {
-      setTimeout(this.onClose.bind(this), timeout);
+      const timeoutInterval = setTimeout(this.onClose.bind(this), timeout);
+      this.setState({ timeoutInterval });
     }
   }
 
   public onClose() {
     const { onClose } = this.props;
+    const { timeoutInterval } = this.state;
+
+    // Check to see if this notification is already set up to be closed
+    // automatically. if it is and the user is pre-emptively closing it,
+    // then cancel the timer.
+    if (timeoutInterval) {
+      clearInterval(timeoutInterval);
+    }
+
     // set thet state to "isClosing" and then kick off a timer for a half second.
     // this allows us to set a classname on the component to animate it out.
     this.setState({ isClosing: true });

--- a/src/ts/views/widgets/toast.tsx
+++ b/src/ts/views/widgets/toast.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import * as classnames from 'classnames';
+
+class Toast extends React.Component<{
+  children: any,
+  timeout?: number,
+  onClose?: () => void
+}, {
+  isClosing?: boolean
+}> {
+  constructor(props: any) {
+    super(props);
+    this.state = {
+      isClosing: false
+    };
+  }
+
+  public componentDidMount() {
+    // Check to see if this is an auto-close Toast
+    const { timeout } = this.props;
+
+    if (timeout) {
+      setTimeout(this.onClose.bind(this), timeout);
+    }
+  }
+
+  public onClose() {
+    const { onClose } = this.props;
+    // set thet state to "isClosing" and then kick off a timer for a half second.
+    // this allows us to set a classname on the component to animate it out.
+    this.setState({ isClosing: true });
+    setTimeout(onClose, 500);
+  }
+
+  public render() {
+    const { children, onClose } = this.props;
+    const { isClosing } = this.state;
+    return (
+      <div className={classnames('toast', { isClosing })}>
+        <div className="toast-content">
+          { children }
+        </div>
+
+        {
+          onClose ?
+          <div className="toast-dismiss icon-x" onClick={this.onClose.bind(this)} />
+          : null
+        }
+      </div>
+    );
+  }
+}
+
+export default Toast;

--- a/viewer-app/root.tsx
+++ b/viewer-app/root.tsx
@@ -42,7 +42,8 @@ class Root extends React.Component<{}, {
   modalShowing?: boolean
   numberInputValue?: number,
   toastShowing?: boolean,
-  toastTimeout?: number
+  toastTimeout?: number,
+  toastContent?: string
 }> {
 
   constructor(props: any) {
@@ -62,7 +63,8 @@ class Root extends React.Component<{}, {
       modalShowing: false,
       numberInputValue: 0,
       toastShowing: false,
-      toastTimeout: null
+      toastTimeout: null,
+      toastContent: null
     };
   }
 
@@ -128,9 +130,10 @@ class Root extends React.Component<{}, {
     this.setState({ numberInputValue: newValue });
   }
 
-  public toggleToast(timeout?) {
+  public toggleToast(textContent: string, timeout?: number) {
     this.setState({
       toastShowing: !this.state.toastShowing,
+      toastContent: textContent,
       toastTimeout: timeout
     });
   }
@@ -151,7 +154,8 @@ class Root extends React.Component<{}, {
       numberInputValue,
       modalShowing,
       toastShowing,
-      toastTimeout
+      toastTimeout,
+      toastContent
     } = this.state;
 
     const tabNames = ['tab 1', 'this is getting out of hand', 'tab 3', 'tab 4'];
@@ -167,14 +171,26 @@ class Root extends React.Component<{}, {
             {
               toastShowing ?
               <Toast onClose={this.toggleToast.bind(this)} timeout={toastTimeout}>
-                {'Action Successful'}
+                {toastContent}
               </Toast>
               : null
             }
           </div>
+          <ButtonGroup>
+            <Button
+              color="white"
+              onClick={this.toggleToast.bind(this, 'open until closed', null)}
+            >
+              {'Show Notification'}
+            </Button>
 
-          <Button color="white" onClick={this.toggleToast.bind(this, null)}>{'Show Notification'}</Button>
-          <Button color="white" onClick={this.toggleToast.bind(this, 4000)}>{'Show Timed Notification'}</Button>
+            <Button
+              color="white"
+              onClick={this.toggleToast.bind(this, 'auto close', 4000)}
+            >
+              {'Show Timed Notification'}
+            </Button>
+          </ButtonGroup>
         </ComponentSection>
 
         <ComponentSection title={'Button Group'}>

--- a/viewer-app/root.tsx
+++ b/viewer-app/root.tsx
@@ -22,7 +22,8 @@ import {
   CircleButton,
   ButtonGroup,
   Avatar,
-  NumberInput
+  NumberInput,
+  Toast
 } from '../src/ts/index';
 
 class Root extends React.Component<{}, {
@@ -39,7 +40,9 @@ class Root extends React.Component<{}, {
   sliderValue: number,
   breadCrumbPath: string[],
   modalShowing?: boolean
-  numberInputValue?: number
+  numberInputValue?: number,
+  toastShowing?: boolean,
+  toastTimeout?: number
 }> {
 
   constructor(props: any) {
@@ -57,7 +60,9 @@ class Root extends React.Component<{}, {
       sliderValue: 2,
       breadCrumbPath: ['Level 1', 'Level 2', 'Level 3'],
       modalShowing: false,
-      numberInputValue: 0
+      numberInputValue: 0,
+      toastShowing: false,
+      toastTimeout: null
     };
   }
 
@@ -123,6 +128,13 @@ class Root extends React.Component<{}, {
     this.setState({ numberInputValue: newValue });
   }
 
+  public toggleToast(timeout?) {
+    this.setState({
+      toastShowing: !this.state.toastShowing,
+      toastTimeout: timeout
+    });
+  }
+
   public render() {
     const wrapperStyle = {
       padding: '15px',
@@ -137,7 +149,9 @@ class Root extends React.Component<{}, {
       activeRadioButtonID,
       checkboxValue,
       numberInputValue,
-      modalShowing
+      modalShowing,
+      toastShowing,
+      toastTimeout
     } = this.state;
 
     const tabNames = ['tab 1', 'this is getting out of hand', 'tab 3', 'tab 4'];
@@ -148,6 +162,20 @@ class Root extends React.Component<{}, {
 
     return (
       <div style={wrapperStyle}>
+        <ComponentSection title={'Toast Notifications'}>
+          <div className="toast-wrapper">
+            {
+              toastShowing ?
+              <Toast onClose={this.toggleToast.bind(this)} timeout={toastTimeout}>
+                {'Action Successful'}
+              </Toast>
+              : null
+            }
+          </div>
+
+          <Button color="white" onClick={this.toggleToast.bind(this, null)}>{'Show Notification'}</Button>
+          <Button color="white" onClick={this.toggleToast.bind(this, 4000)}>{'Show Timed Notification'}</Button>
+        </ComponentSection>
 
         <ComponentSection title={'Button Group'}>
           <ButtonGroup>


### PR DESCRIPTION
These toasts components are stateless, so in `platform-webapp` we'll need a controller and reducer and actions to track the state of which ones are open and what they display etc etc.

Basically for now I put that logic into `root.tsx` with the rest of the examples, but it can be much more flexible when we drop it into our `redux` stuff!

![toasts](https://user-images.githubusercontent.com/5408720/40070574-77cb0b92-583c-11e8-995f-dcdc3fb54bff.gif)

# TODO
- [x] TESTS