### PR TITLE
Style classnames props

### DIFF
--- a/src/ts/views/buttons/button-group.tsx
+++ b/src/ts/views/buttons/button-group.tsx
@@ -1,10 +1,15 @@
 import * as React from 'react';
+import * as classnames from 'classnames';
 
-const ButtonGroup = ({ children }: {
-  children: any
+const ButtonGroup = ({ children, className, style }: {
+  children: any,
+  className?: string,
+  style?: any
 }) => {
+  const wrapperClass = classnames('button-group', className);
+
   return (
-    <div className="button-group">
+    <div className={wrapperClass} style={style}>
       {children}
     </div>
   );

--- a/src/ts/views/buttons/button.tsx
+++ b/src/ts/views/buttons/button.tsx
@@ -29,6 +29,7 @@ const Button = (props: {
       <button
         onClick={disabled ? null : onClick}
         className={buttonClass}
+        style={style}
       >
         {children}
       </button>

--- a/src/ts/views/buttons/circle.tsx
+++ b/src/ts/views/buttons/circle.tsx
@@ -15,7 +15,7 @@ const CircleButton = (props: {
     onClick,
     disabled,
     children
-  } = this.props;
+  } = props;
 
   return (
     <Button {...props}

--- a/src/ts/views/buttons/circle.tsx
+++ b/src/ts/views/buttons/circle.tsx
@@ -9,14 +9,22 @@ const CircleButton = (props: {
   onClick?: () => void,
   disabled?: boolean
 }) => {
+  const {
+    className,
+    style,
+    onClick,
+    disabled,
+    children
+  } = this.props;
+
   return (
     <Button {...props}
-      onClick={props.onClick}
-      className={classnames('circle', props.className)}
-      style={props.style}
-      disabled={props.disabled}
+      onClick={onClick}
+      className={classnames('circle', className)}
+      style={style}
+      disabled={disabled}
     >
-      {props.children}
+      {children}
     </Button>
   );
 };

--- a/src/ts/views/buttons/file-button.tsx
+++ b/src/ts/views/buttons/file-button.tsx
@@ -8,6 +8,8 @@ const FileButton = (props: {
   accept?: string,
   single?: boolean,
   disabled?: boolean,
+  className?: string,
+  style?: any
 
   onChange?: () =>  void,
   onClick?: () => void
@@ -19,10 +21,12 @@ const FileButton = (props: {
     onChange,
     onClick,
     disabled,
-    inputID
+    inputID,
+    className,
+    style
   } = props;
 
-  const wrapperClass = classnames('file-button', {
+  const wrapperClass = classnames('file-button', className, {
     disabled: props.disabled
   });
   const inputClass = classnames('file-button-input', {
@@ -33,6 +37,7 @@ const FileButton = (props: {
     <label htmlFor={inputID} className={wrapperClass}>
       <div>{children}</div>
       <input className={inputClass}
+        style={style}
         type="file"
         id={inputID}
         multiple={single ? false : true}

--- a/src/ts/views/buttons/page-button.tsx
+++ b/src/ts/views/buttons/page-button.tsx
@@ -5,16 +5,19 @@ const PageButton = (props: {
   pageNumber: number,
   onClick?: (pageNumber: number) => void,
   disabled?: boolean,
-  className?: string
+  className?: string,
+  style?: any
 }) => {
-    const { pageNumber, onClick, disabled, className } = props;
+    const { pageNumber, onClick, disabled, className, style } = props;
     const pageButtonClass = classnames('page-button', className, {
       disabled
     });
 
     return (
         <div onClick={disabled ? null : () => onClick(pageNumber)}
-          className={pageButtonClass}>
+          className={pageButtonClass}
+          style={style}
+        >
           {pageNumber}
         </div>
     );

--- a/src/ts/views/inputs/checkbox.tsx
+++ b/src/ts/views/inputs/checkbox.tsx
@@ -6,7 +6,9 @@ const Checkbox = (props: {
   checked?: boolean,
   indeterminate?: boolean,
   label?: string,
-  disabled?: boolean
+  disabled?: boolean,
+  className?: string,
+  style?: any
 }) => {
 
   const {
@@ -14,13 +16,17 @@ const Checkbox = (props: {
     checked,
     indeterminate,
     label,
-    disabled
+    disabled,
+    className,
+    style
   } = props;
 
-  const checkboxClass = classnames('checkbox-component-wrapper', { disabled });
+  const checkboxClass = classnames('checkbox-component-wrapper', className, { disabled });
 
   return (
-      <div className={checkboxClass}>
+      <div className={checkboxClass}
+        style={style}
+      >
         <div className={classnames('psuedo-box', { checked: checked || indeterminate })}>
           <div
             className={classnames('checkbox', { checked: checked || indeterminate })}

--- a/src/ts/views/inputs/checkbox.tsx
+++ b/src/ts/views/inputs/checkbox.tsx
@@ -24,7 +24,8 @@ const Checkbox = (props: {
   const checkboxClass = classnames('checkbox-component-wrapper', className, { disabled });
 
   return (
-      <div className={checkboxClass}
+      <div
+        className={checkboxClass}
         style={style}
       >
         <div className={classnames('psuedo-box', { checked: checked || indeterminate })}>

--- a/src/ts/views/inputs/dropdown.tsx
+++ b/src/ts/views/inputs/dropdown.tsx
@@ -2,7 +2,10 @@ import * as React from 'react';
 import * as classnames from 'classnames';
 
 class Dropdown extends React.Component<{
-  wrapperClassName?: string;
+  wrapperClassName?: string,
+  wrapperStyle?: any,
+  inputClassName?: string,
+  inputStyle?: any
   options: any,
   onOptionSelected: (newOption: string) => void,
   resultRenderer?: (result: string) => any;
@@ -108,13 +111,16 @@ class Dropdown extends React.Component<{
   }
 
   public render() {
-    const { wrapperClassName } = this.props;
+    const { wrapperClassName, wrapperStyle, inputClassName, inputStyle } = this.props;
     const { searchText, isCollapsed } = this.state;
 
     return (
-      <div className={classnames('dropdown-wrapper', wrapperClassName)}>
+      <div className={classnames('dropdown-wrapper', wrapperClassName)}
+        style={wrapperStyle}
+      >
         <input
-          className={classnames('dropdown', { 'is-collapsed': isCollapsed })}
+          className={classnames('dropdown', inputClassName, { 'is-collapsed': isCollapsed })}
+          style={inputStyle}
           value={searchText}
           placeholder="Dropdown ..."
           onChange={this.onTextUpdate.bind(this)}

--- a/src/ts/views/inputs/input.tsx
+++ b/src/ts/views/inputs/input.tsx
@@ -14,6 +14,8 @@ const Input = (props: {
   containerStyle?: any,
   inputStyle?: any,
   round?: boolean,
+  wrapperClassName?: string,
+  inputClassName?: string,
 
   onSubmission?: () => void,
   onHandleChange: (evt: any) => void
@@ -33,7 +35,9 @@ const Input = (props: {
     maxLength,
     containerStyle,
     inputStyle,
-    round
+    round,
+    wrapperClassName,
+    inputClassName
   } = props;
 
   // If a pattern AND a validation state get passed in the pattern takes priority. (Shouldnt ever pass it both)
@@ -45,9 +49,9 @@ const Input = (props: {
   else if (validationState) {
     isValid = validationState;
   }
-  const inputContainerClass = classnames('input-container', { disabled });
+  const inputContainerClass = classnames('input-container', wrapperClassName, { disabled });
 
-  const inputClass = classnames('input-component', {
+  const inputClass = classnames('input-component', inputClassName, {
     disabled,
     valid: isValid,
     invalid: isValid === false && value.length > 0,

--- a/src/ts/views/inputs/number-input.tsx
+++ b/src/ts/views/inputs/number-input.tsx
@@ -13,6 +13,8 @@ const NumberInput = (props: {
   max?: number,
   min?: number,
   placeholder?: string,
+  className?: string,
+  style?: any,
 
   handleChange: (newValue: number) => void
 }) => {
@@ -22,13 +24,15 @@ const NumberInput = (props: {
     max,
     min,
     placeholder,
-    handleChange
+    handleChange,
+    className,
+    style
   } = props;
 
   const isValid = (max && min) && (value >= min) && (value <= max);
   const isInvalid = (max && min) && !isValid;
 
-  const inputContainerClass = classnames('input-container number', { disabled });
+  const inputContainerClass = classnames('input-container number', className, { disabled });
 
   const inputClass = classnames('input-component number', {
     disabled,
@@ -66,6 +70,7 @@ const NumberInput = (props: {
         value={value}
         placeholder={placeholder}
         disabled={disabled}
+        style={style}
       />
       <div className="number-input-button-wrapper">
         <div className={incrementButtonName} onClick={disabled ? null : guardedIncrement}>

--- a/src/ts/views/inputs/radio-button.tsx
+++ b/src/ts/views/inputs/radio-button.tsx
@@ -5,6 +5,7 @@ const RadioButton = (props: {
   activeLabel?: string,
   label?: string,
   wrapperClassName?: string,
+  style?: any,
   disabled?: boolean,
 
   onClick: (key: number | string) => void
@@ -14,7 +15,8 @@ const RadioButton = (props: {
     label,
     wrapperClassName,
     disabled,
-    onClick
+    onClick,
+    style
   } = props;
 
   const checked = label === activeLabel;
@@ -25,7 +27,10 @@ const RadioButton = (props: {
   const innerCircleClass = classnames('inner-circle', { checked, disabled });
 
   return (
-    <div className={wrapperClass} onClick={disabled ? null : () => onClick(label)}>
+    <div className={wrapperClass}
+      onClick={disabled ? null : () => onClick(label)}
+      style={style}
+    >
       <div className={outerCircleClass}>
         <div className={innerCircleClass} />
       </div>

--- a/src/ts/views/inputs/textarea.tsx
+++ b/src/ts/views/inputs/textarea.tsx
@@ -7,6 +7,8 @@ const Textarea = (props: {
   placeholder?: string,
   maxLength?: number,
   fixedSize?: boolean,
+  className?: string,
+  style?: any,
 
   onSubmission?: () => void,
   onHandleChange: () => {}
@@ -20,9 +22,11 @@ const Textarea = (props: {
     fixedSize,
     onSubmission,
     onHandleChange,
+    className,
+    style
   } = props;
 
-  const inputContainerClass = classnames('input-container', { disabled });
+  const inputContainerClass = classnames('input-container', className, { disabled });
   const textareaClassname = classnames('input-component', {
     disabled,
     fixedSize
@@ -37,6 +41,7 @@ const Textarea = (props: {
           onChange={disabled ? null : onHandleChange}
           placeholder={placeholder ? placeholder : null}
           value={value}
+          style={style}
         />
       </div>
   );

--- a/src/ts/views/modals/modal.tsx
+++ b/src/ts/views/modals/modal.tsx
@@ -5,6 +5,7 @@ const Modal = (props: {
   children?: any,
   showing?: boolean,
   wrapperClassName?: string,
+  style?: any,
 
   onClose: () => void
 }) => {
@@ -12,14 +13,15 @@ const Modal = (props: {
     children,
     showing,
     wrapperClassName,
-    onClose
+    onClose,
+    style
   } = props;
 
   const wrapperClass = classnames('modal-wrapper', wrapperClassName, { showing });
 
   // TODO: X to icon
   return (
-    <div className={wrapperClass}>
+    <div className={wrapperClass} style={style}>
       <div className="modal">
         <div className="icon-x close-button" onClick={onClose} />
         {children}

--- a/src/ts/views/widgets/audio-player.tsx
+++ b/src/ts/views/widgets/audio-player.tsx
@@ -5,6 +5,7 @@ import Wavesurfer from 'react-wavesurfer';
 
 const AudioPlayer = (props: {
   className?: string,
+  style?: any,
   playing: boolean,
   audioURL: string,
   pos: number,
@@ -13,6 +14,7 @@ const AudioPlayer = (props: {
 
   const {
     className,
+    style,
     audioURL,
     playing,
     pos,
@@ -26,7 +28,9 @@ const AudioPlayer = (props: {
   };
 
   return (
-    <div className={classnames('audio-player-wrapper', className)}>
+    <div className={classnames('audio-player-wrapper', className)}
+      style={style}
+    >
       <Wavesurfer
         volume={1}
         responsive={true}

--- a/src/ts/views/widgets/avatar.tsx
+++ b/src/ts/views/widgets/avatar.tsx
@@ -8,6 +8,7 @@ const Avatar = (props: {
   width: number,
   circle?: boolean,
   avatarStyle?: any,
+  wrapperStyle?: any,
   wrapperClass?: string,
   avatarClass?: string
 }) => {
@@ -18,6 +19,7 @@ const Avatar = (props: {
     width,
     circle,
     avatarStyle,
+    wrapperStyle,
     wrapperClass,
     avatarClass
   } = props;
@@ -31,7 +33,7 @@ const Avatar = (props: {
   });
 
   return (
-    <div className={avatarWrapperClass}>
+    <div className={avatarWrapperClass} style={wrapperStyle}>
       <Image
         url={imgSrc}
         height={height}

--- a/src/ts/views/widgets/breadcrumbs.tsx
+++ b/src/ts/views/widgets/breadcrumbs.tsx
@@ -1,14 +1,20 @@
 import * as React from 'react';
 import * as classnames from 'classnames';
 
-const BreadCrumbs = ({ path, onClick }: {
+const BreadCrumbs = ({ path, onClick, className, style }: {
+  className?: string,
+  style?: any,
   path: string[],
   onClick?: (clickedCrumbIndex: number) => void
 }) => {
 
+  const breadCrumbClass = classnames('breadcrumb', className);
+
   const crumbs = path.map((label, i) => {
     return (
-      <div key={i} className="breadcrumb">
+      <div key={i} className={breadCrumbClass}
+        style={style}
+      >
         <span
           className={classnames('label', { 'is-active': i === path.length - 1 })}
           onClick={onClick ? onClick.bind(null, i) : null}

--- a/src/ts/views/widgets/pagination.tsx
+++ b/src/ts/views/widgets/pagination.tsx
@@ -5,9 +5,11 @@ import * as classnames from 'classnames';
 const Pagination = (props: {
   activePage: number,
   totalPages: number,
-  onClick: (pageNumber: number) => void
+  onClick: (pageNumber: number) => void,
+  className?: string,
+  style?: any
 }) => {
-    const { activePage, totalPages, onClick } = props;
+    const { activePage, totalPages, onClick, className, style } = props;
     const breakElement = <div className="icon-more-horizontal pagination-break"/>;
     const allPageElements = [];
     let pageRangeArr = [];
@@ -89,8 +91,12 @@ const Pagination = (props: {
       );
     }
 
+    const wrapperClass = classnames('pagination-container', className);
+
     return (
-      <div className="pagination-container">
+      <div className={wrapperClass}
+        style={style}
+      >
         {activePage === 0 ? null
           : <div className="pagination-button icon-chevron-left" onClick={() => onClick(activePage - 1)} />}
         {pageRange}

--- a/src/ts/views/widgets/pill.tsx
+++ b/src/ts/views/widgets/pill.tsx
@@ -8,15 +8,19 @@ const Pill = (props: {
   children?: any,
   onClick?: () => void,
   active?: boolean,
-  className?: string
+  className?: string,
+  style?: any
 }) => {
-  const { type, removeable, children, onClick, className, active, title } = props;
+  const { type, removeable, children, onClick, className, active, title, style } = props;
 
   const pillWrapperClass = classnames('pill', type, className, { removeable, active });
   const removeIcon = <span className="icon-x"></span>;
 
   return (
-    <div className={pillWrapperClass} onClick={onClick ? onClick : null}>
+    <div className={pillWrapperClass}
+      onClick={onClick ? onClick : null}
+      style={style}
+    >
       {children}
       <span className="pill-title">{title}</span>
       { removeable ? <div className="icon-section">{removeIcon}</div> : null }

--- a/src/ts/views/widgets/progress-dots.tsx
+++ b/src/ts/views/widgets/progress-dots.tsx
@@ -5,6 +5,7 @@ const ProgressDots = (props: {
   currentStep?: number,
   totalSteps: number,
   className?: string,
+  // Style is for the dots themselves
   style?: any
 
   stepOnClick?: (step: number) => void;

--- a/src/ts/views/widgets/progress-dots.tsx
+++ b/src/ts/views/widgets/progress-dots.tsx
@@ -4,13 +4,17 @@ import * as classnames from 'classnames';
 const ProgressDots = (props: {
   currentStep?: number,
   totalSteps: number,
+  className?: string,
+  style?: any
 
   stepOnClick?: (step: number) => void;
 }) => {
   const {
     currentStep,
     totalSteps,
-    stepOnClick
+    stepOnClick,
+    className,
+    style
   } = props;
 
   const dotElements = [];
@@ -25,9 +29,12 @@ const ProgressDots = (props: {
         className={dotClass}
         key={i}
         onClick={i === currentStep ? null : () => stepOnClick(i)}
+        style={style}
       />
     );
   }
+
+  const containerClass = classnames('progress-dots-wrapper', className);
 
   return (
     <div className="progress-dots-wrapper">

--- a/src/ts/views/widgets/progress-tabs.tsx
+++ b/src/ts/views/widgets/progress-tabs.tsx
@@ -3,19 +3,23 @@ import * as classnames from 'classnames';
 
 const ProgressTabs = (props: {
   currentTab?: number,
-  tabNames: string[]
+  tabNames: string[],
+  className?: string,
+  style?: any,
 
   tabOnClick?: (step: number) => void;
 }) => {
   const {
     currentTab,
     tabNames,
-    tabOnClick
+    tabOnClick,
+    className,
+    style
   } = props;
 
   const tabElements = [];
   for (let i = 0; i < tabNames.length; i++) {
-    const tabClass = classnames('tab', {
+    const tabClass = classnames('tab', className, {
       active: i === currentTab,
       clickable: i !== currentTab,
     });
@@ -23,6 +27,7 @@ const ProgressTabs = (props: {
       <div
         className={tabClass}
         key={i}
+        style={style}
         onClick={i === currentTab ? null : () => tabOnClick(i)}
       >
         {`${tabNames[i].toUpperCase()}`}

--- a/src/ts/views/widgets/slider.tsx
+++ b/src/ts/views/widgets/slider.tsx
@@ -1,17 +1,31 @@
 import * as React from 'react';
 import Slider from 'rc-slider';
 
-export default ({ value, min, max, disabled, onChange }: {
+export default (props: {
   value: number,
   min: number,
   max: number,
   disabled?: boolean,
+  className?: string,
+  // Style is for the container
+  style?: any,
   onChange?: (newValue: number) => void
 }) => {
+  const {
+    value,
+    min,
+    max,
+    disabled,
+    className,
+    style,
+    onChange
+  } = this.props;
+
   return (
-    <div>
+    <div style={style}>
       <Slider
         value={value}
+        className={className}
         min={min}
         max={max}
         disabled={disabled}

--- a/src/ts/views/widgets/slider.tsx
+++ b/src/ts/views/widgets/slider.tsx
@@ -19,7 +19,7 @@ export default (props: {
     className,
     style,
     onChange
-  } = this.props;
+  } = props;
 
   return (
     <div style={style}>

--- a/src/ts/views/widgets/toast.tsx
+++ b/src/ts/views/widgets/toast.tsx
@@ -4,6 +4,8 @@ import * as classnames from 'classnames';
 class Toast extends React.Component<{
   children: any,
   timeout?: number,
+  className?: string,
+  style?: any,
   onClose?: () => void
 }, {
   isClosing?: boolean,
@@ -45,10 +47,11 @@ class Toast extends React.Component<{
   }
 
   public render() {
-    const { children, onClose } = this.props;
+    const { children, onClose, className, style } = this.props;
     const { isClosing } = this.state;
+    const toastClass = classnames('toast', className, { isClosing });
     return (
-      <div className={classnames('toast', { isClosing })}>
+      <div className={toastClass} style={style}>
         <div className="toast-content">
           { children }
         </div>

--- a/src/ts/views/widgets/toggle-switch.tsx
+++ b/src/ts/views/widgets/toggle-switch.tsx
@@ -8,7 +8,8 @@ const ToggleSwitch = (props: {
   disabled?: boolean,
   color?: string,
   children?: any,
-  className?: string
+  className?: string,
+  style?: any
 }) => {
 
   const {
@@ -17,7 +18,8 @@ const ToggleSwitch = (props: {
     disabled,
     color,
     children,
-    className
+    className,
+    style
   } = props;
 
   // These give us the option to customize a bit more, but they won't override the defaults for now
@@ -25,7 +27,7 @@ const ToggleSwitch = (props: {
   const handleStyle = classnames('react-switch-handle', { active });
 
   return (
-    <div className={wrapperClass}>
+    <div className={wrapperClass} style={style}>
       <Switch
         checked={props.active}
         onChange={props.onClick}

--- a/src/ts/views/widgets/toggle-switch.tsx
+++ b/src/ts/views/widgets/toggle-switch.tsx
@@ -9,6 +9,7 @@ const ToggleSwitch = (props: {
   color?: string,
   children?: any,
   className?: string,
+  // Style is for the wrapper
   style?: any
 }) => {
 
@@ -23,13 +24,14 @@ const ToggleSwitch = (props: {
   } = props;
 
   // These give us the option to customize a bit more, but they won't override the defaults for now
-  const wrapperClass = classnames('toggle-switch-wrapper', className);
+  const wrapperClass = classnames('toggle-switch-wrapper');
   const handleStyle = classnames('react-switch-handle', { active });
 
   return (
     <div className={wrapperClass} style={style}>
       <Switch
         checked={props.active}
+        className={className}
         onChange={props.onClick}
         disabled={disabled}
         onColor={color ? color : '#0076FF'}

--- a/src/ts/views/widgets/user-pill.tsx
+++ b/src/ts/views/widgets/user-pill.tsx
@@ -15,7 +15,8 @@ const UserPill = (props: {
   const { type, userName, imgSrc, removeable, active, className, style } = props;
   const userPillClass = classnames('user-pill', className);
   return (
-    <Pill type={type}
+    <Pill
+      type={type}
       removeable={removeable}
       style={style}
       className={userPillClass}

--- a/src/ts/views/widgets/user-pill.tsx
+++ b/src/ts/views/widgets/user-pill.tsx
@@ -8,11 +8,20 @@ const UserPill = (props: {
   userName?: string,
   imgSrc: string,
   removeable?: boolean,
-  active?: boolean
+  active?: boolean,
+  className?: string,
+  style?: any
 }) => {
-  const { type, userName, imgSrc, removeable, active } = props;
+  const { type, userName, imgSrc, removeable, active, className, style } = props;
+  const userPillClass = classnames('user-pill', className);
   return (
-    <Pill type={type} removeable={removeable} className="user-pill" title={userName} active={active}>
+    <Pill type={type}
+      removeable={removeable}
+      style={style}
+      className={userPillClass}
+      title={userName}
+      active={active}
+    >
       <Avatar wrapperClass="user-pill-avatar" imgSrc={imgSrc} height={32} width={32} circle={true}/>
     </Pill>
   );


### PR DESCRIPTION
My convention (or lack thereof) is that most the time if it's an input of some sort, I pass the style prop to it, otherwise to the wrapper. Some get props for both containers and children if the file already had specific classes/style differentiators for both.