### PR TITLE
Placeholder grey images

### DIFF
--- a/src/ts/views/widgets/avatar.tsx
+++ b/src/ts/views/widgets/avatar.tsx
@@ -39,7 +39,8 @@ const Avatar = (props: {
         height={height}
         width={width}
         className={innerWrapper}
-        style={avatarStyle}/>
+        style={avatarStyle}
+      />
     </div>
   );
 };

--- a/src/ts/views/widgets/image.tsx
+++ b/src/ts/views/widgets/image.tsx
@@ -18,11 +18,18 @@ const Image = (props: {
 
   const imageClass = classnames('image-wrapper', className);
   const customStyle = style || {};
-  const backgroundStyle = {
-    backgroundImage: `url(${url})`,
+  const backgroundStyle: any = {
     height: `${height}px`,
     width: `${width}px`
   };
+
+  if (url) {
+    backgroundStyle.backgroundImage = `url(${url})`;
+  }
+
+  else {
+    backgroundStyle.background = '#E5E5E5';
+  }
 
   return (
     <div


### PR DESCRIPTION
If we say, didn't have a basename for a users image, we'd still try to fetch `files.flite.test/undefined.jpg`. Das no good!

Now if `url` is falsy going into the `<Image>` component, we just render a placeholder grey.

Once this is approved i'll build a new version and import that into my platform-webapp branch